### PR TITLE
feat: handle locale when adding version to links

### DIFF
--- a/.changeset/red-months-perform.md
+++ b/.changeset/red-months-perform.md
@@ -1,0 +1,5 @@
+---
+'starlight-versions': patch
+---
+
+Update link generation to handle locale if present

--- a/.changeset/red-months-perform.md
+++ b/.changeset/red-months-perform.md
@@ -2,4 +2,4 @@
 'starlight-versions': patch
 ---
 
-Update link generation to handle locale if present
+Fixes potential issue with link generation in multilingual projects.

--- a/packages/starlight-versions/libs/markdown.ts
+++ b/packages/starlight-versions/libs/markdown.ts
@@ -196,7 +196,18 @@ function addVersionToLink(link: string, file: VFile) {
   }
 
   const segments = link.split('/')
-  segments.splice(1, 0, file.data.version.slug)
+
+  let slugVersionIndex = 1
+  
+  // If locale exists, insert it before the version slug
+  if (file.data.locale) {
+    const localeIndex = segments.findIndex(segment => segment === file.data.locale)
+    if (localeIndex !== -1) {
+      slugVersionIndex += localeIndex
+    }
+  }
+
+  segments.splice(slugVersionIndex, 0, file.data.version.slug)
 
   if (hasBase) {
     segments.splice(1, 0, stripLeadingSlash(base))

--- a/packages/starlight-versions/libs/markdown.ts
+++ b/packages/starlight-versions/libs/markdown.ts
@@ -198,14 +198,7 @@ function addVersionToLink(link: string, file: VFile) {
   const segments = link.split('/')
 
   let slugVersionIndex = 1
-  
-  // If locale exists, insert it before the version slug
-  if (file.data.locale) {
-    const localeIndex = segments.findIndex(segment => segment === file.data.locale)
-    if (localeIndex !== -1) {
-      slugVersionIndex += localeIndex
-    }
-  }
+  if (file.data.locale && segments[1] === file.data.locale) slugVersionIndex = 2
 
   segments.splice(slugVersionIndex, 0, file.data.version.slug)
 

--- a/packages/starlight-versions/tests/markdown.test.ts
+++ b/packages/starlight-versions/tests/markdown.test.ts
@@ -67,6 +67,15 @@ console.log('Hello, world!')
     `)
   })
 
+  test('transforms Markdown absolute internal links in multilingual projects', async () => {
+    const result = await transformTestMarkdown(`[Test](/fr/test/)`, { locale: 'fr' })
+
+    expect(result.content).toMatchInlineSnapshot(`
+      "[Test](/fr/2.0/test/)
+      "
+    `)
+  })
+
   test('transforms HTML absolute internal links', async () => {
     const result = await transformTestMarkdown(`<a href="https://example.com/">Test 1</a>
 <a href="/test/">Test 2</a>
@@ -78,6 +87,15 @@ console.log('Hello, world!')
       <a href="/2.0/test/">Test 2</a>
       <a href="./test/">Test 3</a>
       <a href="../test/">Test 4</a>
+      "
+    `)
+  })
+
+  test('transforms HTML absolute internal links in multilingual projects', async () => {
+    const result = await transformTestMarkdown(`<a href="/fr/test/">Test</a>`, { locale: 'fr' })
+
+    expect(result.content).toMatchInlineSnapshot(`
+      "<a href="/fr/2.0/test/">Test</a>
       "
     `)
   })
@@ -260,7 +278,7 @@ import test8 from '../../assets/test8.png';
   })
 })
 
-async function transformTestMarkdown(markdown: string) {
+async function transformTestMarkdown(markdown: string, context: TransformTestContext = {}) {
   const result = await transformMarkdown(markdown, {
     assets: [],
     base: '',
@@ -272,6 +290,7 @@ async function transformTestMarkdown(markdown: string) {
       slug: '2.0',
       redirect: 'same-page',
     },
+    ...context,
   })
 
   return {
@@ -279,3 +298,5 @@ async function transformTestMarkdown(markdown: string) {
     content: result.content.replace(/^---\n(?:.|\n)*---\n\n/, ''),
   }
 }
+
+type TransformTestContext = Partial<Parameters<typeof transformMarkdown>[1]>


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
Please provide as much details as possible, including screenshots or sample code if necessary.
-->

**Describe the pull request**

- Adding logic in `addVersionToLink` function to make sure that slug gets appended _after_ the locale, if the page locale exists in the link

**Why**

When dealing with documentation with multiple locales, ie,
```
/docs
├── /es
│   ├── getting-started.mdx
│   └── index.mdx
└── index.html
```
there will be links in the files (e.g. `/es/index.mdx`) such as `/es/getting-started/`. 

When documents with the links during version generation are created, the version slug will be prepended to the link, such as `/v1/es/getting-started/`. 

This causes an issue because when generating a version with the directory, as the locale is typically added _before_ the version slug (ie `/es/v1/getting-started/`) : https://github.com/HiDeoo/starlight-versions/blob/89af03b8cd06cd4581b63a14a5d01865df3c72dd/packages/starlight-versions/libs/versions.ts#L101-L102

As a result, there is a mismatch between the slug of the generated page (e.g. `/es/v1/getting-started/`), and the links on those pages (e.g. `/v1/es/getting-started/`).

**How**

When attempting to add versioning to our [documentation site](https://rafiki.dev/) that has two locales, I was facing this issue. With these changes, the issue was resolved for me. The starlight project can be found here: https://github.com/interledger/rafiki/tree/main/packages/documentation