### PR TITLE
Fix Windows path separator issue with i18n versioned content

### DIFF
--- a/.changeset/tough-clowns-reply.md
+++ b/.changeset/tough-clowns-reply.md
@@ -1,0 +1,5 @@
+---
+'starlight-versions': patch
+---
+
+Fixes a Windows-only issue where archived docs could generate incorrect routes.

--- a/packages/starlight-versions/libs/path.ts
+++ b/packages/starlight-versions/libs/path.ts
@@ -41,7 +41,7 @@ export function getExtension(filePath: string) {
 export function stripExtension(filePath: string) {
   const parsedPath = path.parse(filePath)
 
-  return path.posix.join(parsedPath.dir.replace(/\\/g, '/'), parsedPath.name)
+  return path.posix.join(parsedPath.dir, parsedPath.name)
 }
 
 export function isAbsoluteLink(link: string) {

--- a/packages/starlight-versions/libs/path.ts
+++ b/packages/starlight-versions/libs/path.ts
@@ -41,7 +41,7 @@ export function getExtension(filePath: string) {
 export function stripExtension(filePath: string) {
   const parsedPath = path.parse(filePath)
 
-  return path.posix.join(parsedPath.dir, parsedPath.name)
+  return path.posix.join(parsedPath.dir.replace(/\\/g, '/'), parsedPath.name)
 }
 
 export function isAbsoluteLink(link: string) {

--- a/packages/starlight-versions/libs/starlight.ts
+++ b/packages/starlight-versions/libs/starlight.ts
@@ -18,7 +18,7 @@ export function getFrontmatterNodeValue(frontmatter: StarlightFrontmatter) {
 }
 
 export function getDocSlug(docsDir: URL, doc: URL) {
-  const docPath = path.relative(url.fileURLToPath(docsDir), url.fileURLToPath(doc))
+  const docPath = path.relative(url.fileURLToPath(docsDir), url.fileURLToPath(doc)).replace(/\\/g, '/')
   const slug = slugifyPath(docPath)
 
   return slug === 'index' ? '/' : slug.replace(/\/index$/, '')

--- a/packages/starlight-versions/libs/starlight.ts
+++ b/packages/starlight-versions/libs/starlight.ts
@@ -18,7 +18,7 @@ export function getFrontmatterNodeValue(frontmatter: StarlightFrontmatter) {
 }
 
 export function getDocSlug(docsDir: URL, doc: URL) {
-  const docPath = path.relative(url.fileURLToPath(docsDir), url.fileURLToPath(doc)).replace(/\\/g, '/')
+  const docPath = path.relative(url.fileURLToPath(docsDir), url.fileURLToPath(doc)).replaceAll('\\', '/')
   const slug = slugifyPath(docPath)
 
   return slug === 'index' ? '/' : slug.replace(/\/index$/, '')

--- a/packages/starlight-versions/tests/starlight.test.ts
+++ b/packages/starlight-versions/tests/starlight.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, test } from 'vitest'
+import path from 'node:path'
+
+import { describe, expect, test, vi } from 'vitest'
 
 import { addPrefixToSidebarConfig, getDocSlug } from '../libs/starlight'
 
@@ -19,6 +21,26 @@ describe('getDocSlug', () => {
 
   test('handles nested files', () => {
     expect(getDocSlug(docsDir, new URL('guides/examples/test.mdx', docsDir))).toBe('guides/examples/test')
+  })
+
+  test('handles Windows-style nested files', () => {
+    const relativeSpy = vi.spyOn(path, 'relative').mockReturnValue(String.raw`guides\examples\test.mdx`)
+
+    try {
+      expect(getDocSlug(docsDir, new URL('guides/examples/test.mdx', docsDir))).toBe('guides/examples/test')
+    } finally {
+      relativeSpy.mockRestore()
+    }
+  })
+
+  test('handles Windows-style nested index files', () => {
+    const relativeSpy = vi.spyOn(path, 'relative').mockReturnValue(String.raw`guides\examples\index.mdx`)
+
+    try {
+      expect(getDocSlug(docsDir, new URL('guides/examples/index.mdx', docsDir))).toBe('guides/examples')
+    } finally {
+      relativeSpy.mockRestore()
+    }
   })
 })
 


### PR DESCRIPTION
Why:

On Windows, `path.relative()` returns backslash-separated paths. These were passed to `slugifyPath()` `stripExtension()` which only split on forward slashes, causing locale detection to fail for nested paths like `fr/guides/page.mdx`. This resulted in wrong slugs being injected into versioned locale files (e.g. `1.0/fr-guides/page` instead of `fr/1.0/guides/page`), making those pages 404 on Windows.

How:

Normalize backslashes to forward slashes in `getDocSlug()` (at the OS boundary) and in `stripExtension()` (as a defensive inner fix).

This PR fixes the issue #32