### PR TITLE
Add Markdoc (.mdoc) file support during version archiving

### DIFF
--- a/packages/starlight-versions/libs/markdown.ts
+++ b/packages/starlight-versions/libs/markdown.ts
@@ -10,7 +10,7 @@ import remarkMdx from 'remark-mdx'
 import { CONTINUE, SKIP, visit } from 'unist-util-visit'
 import type { VFile } from 'vfile'
 
-import { isAbsoluteLink, stripLeadingSlash, stripTrailingSlash } from './path'
+import { getExtension, isAbsoluteLink, stripLeadingSlash, stripTrailingSlash } from './path'
 import { getFrontmatterNodeValue, parseFrontmatter } from './starlight'
 import type { Version, VersionAsset } from './versions'
 
@@ -20,9 +20,11 @@ const astroAssetRegex = /\.(png|jpg|jpeg|tiff|webp|gif|svg|avif|.+\?raw)$/i
 const mediaElements = new Set(['img', 'source', 'Image', 'audio', 'video'])
 
 const processor = remark().use(remarkDirective).use(remarkMdx).use(remarkFrontmatter).use(remarkStarlightVersions)
+const markdocProcessor = remark().use(remarkDirective).use(remarkFrontmatter).use(remarkStarlightVersions)
 
 export async function transformMarkdown(markdown: string, context: TransformContext) {
-  const file = await processor.process({
+  const activeProcessor = getExtension(context.url.pathname) === '.mdoc' ? markdocProcessor : processor
+  const file = await activeProcessor.process({
     data: { ...context },
     value: markdown,
   })

--- a/packages/starlight-versions/libs/markdown.ts
+++ b/packages/starlight-versions/libs/markdown.ts
@@ -23,16 +23,38 @@ const processor = remark().use(remarkDirective).use(remarkMdx).use(remarkFrontma
 const markdocProcessor = remark().use(remarkDirective).use(remarkFrontmatter).use(remarkStarlightVersions)
 
 export async function transformMarkdown(markdown: string, context: TransformContext) {
-  const activeProcessor = getExtension(context.url.pathname) === '.mdoc' ? markdocProcessor : processor
+  const ext = getExtension(context.url.pathname)
+  const activeProcessor = ext === '.mdoc' ? markdocProcessor : processor
   const file = await activeProcessor.process({
     data: { ...context },
     value: markdown,
   })
 
+  const content = String(file)
+
   return {
     assets: file.data.assets,
-    content: String(file),
+    content: ext === '.mdoc' ? fixMarkdocTagIndentation(content) : content,
   }
+}
+
+// Remark treats Markdoc block tags ({% %}) with no blank line before them as list
+// item continuations, indenting them on serialization. Strip that leading whitespace,
+// but leave fenced code block contents untouched.
+function fixMarkdocTagIndentation(content: string): string {
+  const lines = content.split('\n')
+  let inCodeBlock = false
+
+  return lines
+    .map((line) => {
+      if (/^[ \t]*(`{3,}|~{3,})/.test(line)) {
+        inCodeBlock = !inCodeBlock
+        return line
+      }
+      if (inCodeBlock) return line
+      return line.replace(/^[ \t]+(\{%)/, '$1')
+    })
+    .join('\n')
 }
 
 export function remarkStarlightVersions() {


### PR DESCRIPTION
### Problem

When archiving a version with `.mdoc` files present, the build would fail with:

```
[AstroUserError] Could not parse expression with acorn
```

This happened because all files were passed through the remark+remarkMdx pipeline regardless of extension. The MDX parser (acorn) cannot handle Markdoc tag syntax (`{% %}`), causing the entire archiving process to abort, and leaving the version directory partially created but without its config JSON, which then caused a secondary error on the next startup:

```
[AstroUserError] Failed to read the version 'x.y' configuration file.
```

### Solution

Two changes were made to `libs/markdown.ts`:

1. **Separate processor for `.mdoc` files** : a second remark processor is used for `.mdoc` files, identical to the existing one but without `remarkMdx`. Frontmatter slug rewriting and link/image transforms still apply via the shared `remarkStarlightVersions` plugin.

2. **Fix block tag indentation** : remark treats a Markdoc block tag on a line immediately after a list item (no blank line) as a continuation of that list item, and indents it on serialization. A post-processing step strips leading whitespace from lines whose first non-whitespace content is a `{%` tag, skipping fenced code block contents.

This fixes issue #40


Note that links in Markdoc tags could stay untransformed, resulting in broken links. But it's better than failing completely. Maybe in those cases we should display a message to the user to double-check Markdoc documentation pages ?

